### PR TITLE
Collecting metrics via scollector

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ If there are errors sending email via gmail - enable `Access for less secure app
 Rocket emoji via https://github.com/twitter/twemoji
 
 ### TODO
-* Store latency information
+* Set alerts based on metric threshold values / calculated values
+* Distinguish between an error performing a check & a failing check. i.e. Check should return two errors.
+* Safely handle concurrent read/writes in key data structures accessed in different goroutines.
 * Change server config on the fly
 * Alternative backoff configurations (e.g. no backoff / exponential backoff after X attempts)
 * Improved handling/recovering from any errors detected in redalert

--- a/checks/scollector.go
+++ b/checks/scollector.go
@@ -1,0 +1,57 @@
+package checks
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TODO:
+// add mutex to handle concurrent read/writes
+
+var GlobalSCollector map[Host]CurrentMetrics = make(map[Host]CurrentMetrics)
+
+type Host string
+type CurrentMetrics map[string]float64
+
+type SCollector struct {
+	Host string
+}
+
+func NewSCollector(host string) *SCollector {
+	return &SCollector{host}
+}
+
+func (sc *SCollector) Check() (map[string]float64, error) {
+
+	fmt.Println("SCollector Check")
+
+	_, exists := GlobalSCollector[Host(sc.Host)]
+	if !exists {
+		GlobalSCollector[Host(sc.Host)] = make(map[string]float64)
+	}
+
+	jsonB, err := json.MarshalIndent(GlobalSCollector[Host(sc.Host)], "", "\t")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(jsonB))
+
+	output := make(map[string]float64)
+	for key, val := range GlobalSCollector[Host(sc.Host)] {
+		output[key] = val
+	}
+
+	return output, nil
+}
+
+func (sc *SCollector) MetricInfo(metric string) MetricInfo {
+	return MetricInfo{Unit: ""}
+}
+
+func (sc *SCollector) RedAlertMessage() string {
+	return "Uhoh fail on " + sc.Host
+}
+
+func (sc *SCollector) GreenAlertMessage() string {
+	return "Woo-hoo, successful check on " + sc.Host
+}

--- a/checks/scollector.go
+++ b/checks/scollector.go
@@ -1,10 +1,5 @@
 package checks
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 // TODO:
 // add mutex to handle concurrent read/writes
 
@@ -23,18 +18,10 @@ func NewSCollector(host string) *SCollector {
 
 func (sc *SCollector) Check() (map[string]float64, error) {
 
-	fmt.Println("SCollector Check")
-
 	_, exists := GlobalSCollector[Host(sc.Host)]
 	if !exists {
 		GlobalSCollector[Host(sc.Host)] = make(map[string]float64)
 	}
-
-	jsonB, err := json.MarshalIndent(GlobalSCollector[Host(sc.Host)], "", "\t")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(string(jsonB))
 
 	output := make(map[string]float64)
 	for key, val := range GlobalSCollector[Host(sc.Host)] {

--- a/config.json.sample
+++ b/config.json.sample
@@ -20,6 +20,13 @@
          "address":"http://server3.com/healthcheck",
          "interval":10,
          "alerts":["stderr"]
+      },
+      {
+         "name": "scollector-metrics",
+         "type": "scollector",
+         "host": "hostname",
+         "interval": 15,
+         "alerts": ["stderr"]
       }
    ],
    "gmail": {

--- a/core/check.go
+++ b/core/check.go
@@ -11,9 +11,14 @@ import (
 type CheckConfig struct {
 	Name     string   `json:"name"`
 	Type     string   `json:"type"`
-	Address  string   `json:"address"`
 	Interval int      `json:"interval"`
 	Alerts   []string `json:"alerts"`
+
+	// used for web-ping
+	Address string `json:"address"`
+
+	// used for scollector
+	Host string `json:"host"`
 }
 
 type Check struct {
@@ -32,11 +37,13 @@ type Check struct {
 func NewCheck(config CheckConfig) *Check {
 
 	var checker Checker
-	if config.Type == "web-ping" {
+	switch config.Type {
+	case "web-ping":
 		id := config.Name + " (" + config.Address + ")"
 		checker = checks.NewWebPinger(id, config.Address)
-	} else {
-		// todo - add validation, handle err gracefully
+	case "scollector":
+		checker = checks.NewSCollector(config.Host)
+	default:
 		panic("unknown type")
 	}
 

--- a/core/check_events.go
+++ b/core/check_events.go
@@ -1,8 +1,6 @@
 package core
 
-import (
-	"strings"
-)
+import "strings"
 
 var MaxEventsStored = 100
 
@@ -34,7 +32,8 @@ func (c *Check) RecentMetrics(metric string) string {
 	for e := c.EventHistory.Front(); e != nil; e = e.Next() {
 		event := e.Value.(*Event)
 		if event != nil {
-			output = append([]string{event.DisplayMetric(metric)}, output...)
+			metricStr := event.DisplayMetric(metric)
+			output = append([]string{metricStr}, output...)
 		}
 	}
 	return strings.Join(output, ",")

--- a/web/metrics_receiver_handler.go
+++ b/web/metrics_receiver_handler.go
@@ -1,0 +1,54 @@
+package web
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+
+	"github.com/jonog/redalert/checks"
+)
+
+type Metric struct {
+	Timestamp int
+	Metric    string
+	Value     float64
+	Tags      map[string]string
+}
+
+func metricsReceiverHandler(c *appCtx, w http.ResponseWriter, r *http.Request) {
+
+	if r.Method != "POST" {
+		http.Error(w, "Invalid request method.", 405)
+		return
+	}
+
+	raw, err := gzip.NewReader(r.Body)
+	if err != nil {
+		http.Error(w, "Internal Server Error", 500)
+		return
+	}
+
+	var metrics []Metric
+	err = json.NewDecoder(raw).Decode(&metrics)
+	if err != nil {
+		http.Error(w, "Internal Server Error", 500)
+		return
+	}
+
+	for _, metric := range metrics {
+
+		host, exists := metric.Tags["host"]
+		if !exists || host == "" {
+			continue
+		}
+
+		_, exists = checks.GlobalSCollector[checks.Host(host)]
+		if !exists {
+			checks.GlobalSCollector[checks.Host(host)] = make(map[string]float64)
+		}
+		checks.GlobalSCollector[checks.Host(host)][metric.Metric] = metric.Value
+	}
+
+	w.WriteHeader(204)
+	w.Write([]byte(`OK`))
+}

--- a/web/web.go
+++ b/web/web.go
@@ -16,8 +16,10 @@ func Run(service *core.Service, port string) {
 
 	box := rice.MustFindBox("static")
 	fs := http.FileServer(box.HTTPBox())
+
 	http.Handle("/static/", http.StripPrefix("/static/", fs))
 	http.Handle("/", appHandler{context, dashboardHandler})
+	http.Handle("/api/put", appHandler{context, metricsReceiverHandler})
 
 	fmt.Println("Listening on port ", port, " ...")
 	err := http.ListenAndServe(":"+port, nil)


### PR DESCRIPTION
Add endpoint / check implementation for collecting metrics.
Metric collection via Bosun's scollector, which sends metrics via HTTP.
Endpoint in Redalert at `/api/put` (OpenTSDB V2 format).
Metrics pushed into a simple map, then read off periodically by the Redalert SCollector Check.