### PR TITLE
add ability to compare exit codes and output of command checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,32 @@ Configure servers to monitor & alert settings via `config.json`.
             "type": "constant",
             "interval": 10
          }
+      },
+      {
+         "name":"compare exit code",
+         "type": "command",
+         "config": {
+            "command": "[ -f /dev/null ]",
+            "expected_exit_code": "1"
+         },
+         "send_alerts": ["stderr"],
+         "backoff": {
+            "type": "constant",
+            "interval": 10
+         }
+      },
+      {
+         "name":"compare output",
+         "type": "command",
+         "config": {
+            "command": "curl -s -o /dev/null -I -w '%{http_code}' http://httpstat.us/408",
+            "expected_output": "408"
+         },
+         "send_alerts": ["stderr"],
+         "backoff": {
+            "type": "constant",
+            "interval": 10
+         }
       }
    ],
    "notifications": [

--- a/config.json.sample
+++ b/config.json.sample
@@ -126,6 +126,32 @@
             "type": "constant",
             "interval": 10
          }
+      },
+      {
+         "name":"compare exit code",
+         "type": "command",
+         "config": {
+            "command": "[ -f /dev/null ]",
+            "expected_exit_code": "1"
+         },
+         "send_alerts": ["stderr"],
+         "backoff": {
+            "type": "constant",
+            "interval": 10
+         }
+      },
+      {
+         "name":"compare output",
+         "type": "command",
+         "config": {
+            "command": "curl -s -o /dev/null -I -w '%{http_code}' http://httpstat.us/408",
+            "expected_output": "408"
+         },
+         "send_alerts": ["stderr"],
+         "backoff": {
+            "type": "constant",
+            "interval": 10
+         }
       }
    ],
    "notifications": [


### PR DESCRIPTION
This pull request adds the ability to specify the expected output of commands or the expected exit code.